### PR TITLE
Added motion-detection support

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -329,6 +329,36 @@ void Adafruit_MPU6050::setFilterBandwidth(mpu6050_bandwidth_t bandwidth) {
 
 /**************************************************************************/
 /*!
+ *     @brief  Gets bandwidth of the Digital High Pass Filter
+ *     @return  The current `mpu6050_highpass_t` filter bandwidth
+ */
+/**************************************************************************/
+mpu6050_highpass_t Adafruit_MPU6050::getHighPassFilter(void) {
+  Adafruit_BusIO_Register config =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_ACCEL_CONFIG, 1);
+
+  Adafruit_BusIO_RegisterBits filter_config =
+      Adafruit_BusIO_RegisterBits(&config, 3, 0);
+  return (mpu6050_highpass_t)filter_config.read();
+}
+
+/**************************************************************************/
+/*!
+ *    @brief Sets the bandwidth of the Digital High-Pass Filter
+ *    @param bandwidth the new `mpu6050_highpass_t` bandwidth
+ */
+/**************************************************************************/
+void Adafruit_MPU6050::setHighPassFilter(mpu6050_highpass_t bandwidth) {
+  Adafruit_BusIO_Register config =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_ACCEL_CONFIG, 1);
+
+  Adafruit_BusIO_RegisterBits filter_config =
+      Adafruit_BusIO_RegisterBits(&config, 3, 0);
+  filter_config.write(bandwidth);
+}
+
+/**************************************************************************/
+/*!
 *     @brief  Sets the polarity of the INT pin when active
 *     @param  active_low
               If `true` the pin will be low when an interrupt is active
@@ -341,6 +371,78 @@ void Adafruit_MPU6050::setInterruptPinPolarity(bool active_low) {
   Adafruit_BusIO_RegisterBits int_level =
       Adafruit_BusIO_RegisterBits(&int_pin_config, 1, 7);
   int_level.write(active_low);
+}
+
+/**************************************************************************/
+/*!
+*     @brief  Sets the latch behavior of the INT pin when active
+*     @param  held
+              If `true` the pin will remain held until cleared
+              If `false` the pin will reset after a 50us pulse
+*/
+/**************************************************************************/
+void Adafruit_MPU6050::setInterruptPinLatch(bool held) {
+  Adafruit_BusIO_Register int_pin_config =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_INT_PIN_CONFIG, 1);
+  Adafruit_BusIO_RegisterBits int_latch =
+      Adafruit_BusIO_RegisterBits(&int_pin_config, 1, 7);
+  int_latch.write(held);
+}
+
+/**************************************************************************/
+/*!
+*     @brief  Sets the motion interrupt
+*     @param  active
+              If `true` motion interrupt will activate based on thr and dur
+              If `false` motion interrupt will be disabled
+*/
+/**************************************************************************/
+void Adafruit_MPU6050::setMotionInterrupt(bool active) {
+  Adafruit_BusIO_Register int_enable =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_INT_ENABLE, 1);
+  Adafruit_BusIO_RegisterBits int_motion =
+      Adafruit_BusIO_RegisterBits(&int_enable, 1, 6);
+  int_motion.write(active);
+}
+
+/**************************************************************************/
+/*!
+ *     @brief  Gets motion interrupt status
+ *     @return  motion_interrupt
+ */
+/**************************************************************************/
+bool Adafruit_MPU6050::getMotionInterruptStatus(void) {
+  Adafruit_BusIO_Register status =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_INT_STATUS, 1);
+
+  Adafruit_BusIO_RegisterBits motion =
+      Adafruit_BusIO_RegisterBits(&status, 1, 6);
+  return (bool)motion.read();
+}
+
+
+/**************************************************************************/
+/*!
+*     @brief  Sets the motion detection threshold
+*     @param  thr
+*/
+/**************************************************************************/
+void Adafruit_MPU6050::setMotionDetectionThreshold(uint8_t thr) {
+  Adafruit_BusIO_Register threshold =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_MOT_THR, 1);
+  threshold.write(thr);
+}
+
+/**************************************************************************/
+/*!
+*     @brief  Sets the motion detection duration
+*     @param  dur
+*/
+/**************************************************************************/
+void Adafruit_MPU6050::setMotionDetectionDuration(uint8_t dur) {
+  Adafruit_BusIO_Register duration =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_MOT_DUR, 1);
+  duration.write(dur);
 }
 
 /**************************************************************************/

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -420,12 +420,11 @@ bool Adafruit_MPU6050::getMotionInterruptStatus(void) {
   return (bool)motion.read();
 }
 
-
 /**************************************************************************/
 /*!
-*     @brief  Sets the motion detection threshold
-*     @param  thr
-*/
+ *     @brief  Sets the motion detection threshold
+ *     @param  thr
+ */
 /**************************************************************************/
 void Adafruit_MPU6050::setMotionDetectionThreshold(uint8_t thr) {
   Adafruit_BusIO_Register threshold =
@@ -435,9 +434,9 @@ void Adafruit_MPU6050::setMotionDetectionThreshold(uint8_t thr) {
 
 /**************************************************************************/
 /*!
-*     @brief  Sets the motion detection duration
-*     @param  dur
-*/
+ *     @brief  Sets the motion detection duration
+ *     @param  dur
+ */
 /**************************************************************************/
 void Adafruit_MPU6050::setMotionDetectionDuration(uint8_t dur) {
   Adafruit_BusIO_Register duration =

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -51,10 +51,9 @@
 #define MPU6050_TEMP_H 0x41     ///< Temperature data high byte register
 #define MPU6050_TEMP_L 0x42     ///< Temperature data low byte register
 #define MPU6050_ACCEL_OUT 0x3B  ///< base address for sensor data reads
-#define MPU6050_MOT_THR 0x1F    // Motion detection threshold bits [7:0]
+#define MPU6050_MOT_THR 0x1F    ///< Motion detection threshold bits [7:0]
 #define MPU6050_MOT_DUR                                                        \
-  0x20 // Duration counter threshold for motion
-       // interrupt generation, 1 kHz rate, LSB = 1 ms
+  0x20 ///< Duration counter threshold for motion int. 1 kHz rate, LSB = 1 ms
 
 /**
  * @brief FSYNC output values

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -40,10 +40,10 @@
 #define MPU6050_GYRO_CONFIG 0x1B ///< Gyro specfic configuration register
 #define MPU6050_ACCEL_CONFIG                                                   \
   0x1C ///< Accelerometer specific configration register
-#define MPU6050_INT_PIN_CONFIG 0x37    ///< Interrupt pin configuration register
-#define MPU6050_INT_ENABLE 0x38    ///< Interrupt enable configuration register
-#define MPU6050_INT_STATUS 0x3A    ///< Interrupt status register
-#define MPU6050_WHO_AM_I 0x75          ///< Divice ID register
+#define MPU6050_INT_PIN_CONFIG 0x37 ///< Interrupt pin configuration register
+#define MPU6050_INT_ENABLE 0x38     ///< Interrupt enable configuration register
+#define MPU6050_INT_STATUS 0x3A     ///< Interrupt status register
+#define MPU6050_WHO_AM_I 0x75       ///< Divice ID register
 #define MPU6050_SIGNAL_PATH_RESET 0x68 ///< Signal path reset register
 #define MPU6050_USER_CTRL 0x6A         ///< FIFO and I2C Master control register
 #define MPU6050_PWR_MGMT_1 0x6B        ///< Primary power/sleep control register
@@ -51,9 +51,10 @@
 #define MPU6050_TEMP_H 0x41     ///< Temperature data high byte register
 #define MPU6050_TEMP_L 0x42     ///< Temperature data low byte register
 #define MPU6050_ACCEL_OUT 0x3B  ///< base address for sensor data reads
-#define MPU6050_MOT_THR 0x1F  // Motion detection threshold bits [7:0]
-#define MPU6050_MOT_DUR 0x20  // Duration counter threshold for motion
-                              // interrupt generation, 1 kHz rate, LSB = 1 ms
+#define MPU6050_MOT_THR 0x1F    // Motion detection threshold bits [7:0]
+#define MPU6050_MOT_DUR                                                        \
+  0x20 // Duration counter threshold for motion
+       // interrupt generation, 1 kHz rate, LSB = 1 ms
 
 /**
  * @brief FSYNC output values

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -41,6 +41,8 @@
 #define MPU6050_ACCEL_CONFIG                                                   \
   0x1C ///< Accelerometer specific configration register
 #define MPU6050_INT_PIN_CONFIG 0x37    ///< Interrupt pin configuration register
+#define MPU6050_INT_ENABLE 0x38    ///< Interrupt enable configuration register
+#define MPU6050_INT_STATUS 0x3A    ///< Interrupt status register
 #define MPU6050_WHO_AM_I 0x75          ///< Divice ID register
 #define MPU6050_SIGNAL_PATH_RESET 0x68 ///< Signal path reset register
 #define MPU6050_USER_CTRL 0x6A         ///< FIFO and I2C Master control register
@@ -49,6 +51,9 @@
 #define MPU6050_TEMP_H 0x41     ///< Temperature data high byte register
 #define MPU6050_TEMP_L 0x42     ///< Temperature data low byte register
 #define MPU6050_ACCEL_OUT 0x3B  ///< base address for sensor data reads
+#define MPU6050_MOT_THR 0x1F  // Motion detection threshold bits [7:0]
+#define MPU6050_MOT_DUR 0x20  // Duration counter threshold for motion
+                              // interrupt generation, 1 kHz rate, LSB = 1 ms
 
 /**
  * @brief FSYNC output values
@@ -119,6 +124,21 @@ typedef enum {
   MPU6050_BAND_10_HZ,  ///< 10 Hz
   MPU6050_BAND_5_HZ,   ///< 5 Hz
 } mpu6050_bandwidth_t;
+
+/**
+ * @brief Accelerometer high pass filter options
+ *
+ * Allowed values for `setHighPassFilter`.
+ */
+typedef enum {
+  MPU6050_HIGHPASS_DISABLE,
+  MPU6050_HIGHPASS_5_HZ,
+  MPU6050_HIGHPASS_2_5_HZ,
+  MPU6050_HIGHPASS_1_25_HZ,
+  MPU6050_HIGHPASS_0_63_HZ,
+  MPU6050_HIGHPASS_UNUSED,
+  MPU6050_HIGHPASS_HOLD,
+} mpu6050_highpass_t;
 
 /**
  * @brief Periodic measurement options
@@ -202,7 +222,16 @@ public:
   void setGyroRange(mpu6050_gyro_range_t);
 
   void setInterruptPinPolarity(bool active_low);
+  void setInterruptPinLatch(bool held);
   void setFsyncSampleOutput(mpu6050_fsync_out_t fsync_output);
+
+  mpu6050_highpass_t getHighPassFilter(void);
+  void setHighPassFilter(mpu6050_highpass_t bandwidth);
+
+  void setMotionInterrupt(bool active);
+  void setMotionDetectionThreshold(uint8_t thr);
+  void setMotionDetectionDuration(uint8_t dur);
+  bool getMotionInterruptStatus(void);
 
   mpu6050_fsync_out_t getFsyncSampleOutput(void);
   void setI2CBypass(bool bypass);


### PR DESCRIPTION
Added support for activating motion interrupts:
- Set motion threshold
- Set duration threshold
- Set high-pass filter for motion detection
- Change interrupt latch behavior and polarity if needed
- Enable motion interrupt

Useful for waking the MCU from sleep modes, based on motion trigger.

Caveat: the MPU6050 motion-detection mode is not power efficient.  Much better than keeping the entire MCU awake, but not as efficient as I hoped.