### PR TITLE
Fix memory leak

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -119,12 +119,12 @@ bool Adafruit_MPU6050::_init(int32_t sensor_id) {
 
   // remove old reference
   if (temp_sensor)
-      delete temp_sensor;
+    delete temp_sensor;
   if (accel_sensor)
-      delete accel_sensor;
+    delete accel_sensor;
   if (gyro_sensor)
-      delete gyro_sensor;
-  
+    delete gyro_sensor;
+
   temp_sensor = new Adafruit_MPU6050_Temp(this);
   accel_sensor = new Adafruit_MPU6050_Accelerometer(this);
   gyro_sensor = new Adafruit_MPU6050_Gyro(this);

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -117,6 +117,14 @@ bool Adafruit_MPU6050::_init(int32_t sensor_id) {
 
   delay(100);
 
+  // remove old reference
+  if (temp_sensor)
+    delete temp_sensor;
+  if (accel_sensor)
+    delete accel_sensor;
+  if (gyro_sensor)
+    delete gyro_sensor;
+  
   temp_sensor = new Adafruit_MPU6050_Temp(this);
   accel_sensor = new Adafruit_MPU6050_Accelerometer(this);
   gyro_sensor = new Adafruit_MPU6050_Gyro(this);

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -119,11 +119,11 @@ bool Adafruit_MPU6050::_init(int32_t sensor_id) {
 
   // remove old reference
   if (temp_sensor)
-    delete temp_sensor;
+      delete temp_sensor;
   if (accel_sensor)
-    delete accel_sensor;
+      delete accel_sensor;
   if (gyro_sensor)
-    delete gyro_sensor;
+      delete gyro_sensor;
   
   temp_sensor = new Adafruit_MPU6050_Temp(this);
   accel_sensor = new Adafruit_MPU6050_Accelerometer(this);


### PR DESCRIPTION
Delete old sensors if they have been initialised in an previous call to begin() / init().
Multiple calls to begin() will not delete the old reference and create a memory leak.
Usecase: If the sensor is powered by an Arduino IO pin (Arduino IO-Pin -> MPU6050 VCC) before going to sleep and re-powered after waking up an new initialisation of the sensor via begin() is needed.

Reference to issue: https://github.com/adafruit/Adafruit_MPU6050/issues/7

Example code:
```
#include <Adafruit_MPU6050.h>
#include <Adafruit_Sensor.h>
#include <Wire.h>

Adafruit_MPU6050 mpu;

/* Create new sensor events */
sensors_event_t a, g, temp;

// Learn more about this topic: https://learn.adafruit.com/memories-of-an-arduino/measuring-free-memory
int freeRam () {
  extern int __heap_start, *__brkval; 
  int v; 
  return (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval); 
}

void setup(void) {
  Serial.begin(9600);
  
  Wire.begin();

  // MPU6050 VCC is connected to A2 output 
  pinMode(A2,OUTPUT); digitalWrite(A2,HIGH);
  // Wait for VCC setteling
  delay(15);

  // Try to initialize!
  if (!mpu.begin()) {
    Serial.println("Error init MPU 6050 on setup");
    while (1) {
      delay(10);
    }
  }

  Serial.println("Heap,Accel_X,Accel_Y,Accel_Z");
  
  mpu.enableCycle(false);
  mpu.setCycleRate(MPU6050_CYCLE_1_25_HZ);
  pinMode(LED_BUILTIN,OUTPUT);
  Serial.flush();
}

/* This example is meant to be used with the serial plotter which makes
 *  it easier to see how the readings change with different settings.
 *  Make sure to poke and prod the sensor while the demo is running to
 *  generate some intersting data!
 */
void loop() {

  Wire.begin();
  static float accel_x;
  static float accel_y;
  static float accel_z;
  static const float offset = 0.3;

  // MPU6050 VCC is connected to A2 output 
  pinMode(A2,OUTPUT); digitalWrite(A2,HIGH);
  // Wait for VCC setteling
  delay(15);

  // Workaround -- begin
  // Somehow after power up the MPU6050 doesn't ACK the first transmission so give it 
  // a dummy transmission before calling mpu.begin() later
  Wire.beginTransmission(0x68);
  Wire.endTransmission();
  // Workaround -- end

  Serial.print(freeRam()); Serial.print(",");
  Serial.flush();
  
  if(!mpu.begin())
  {
    Serial.println("Error init MPU 6050 after sleep");
    Serial.flush();
  }
  else
  {
    mpu.getEvent(&a, &g, &temp);
    // Compare old acceleration values with current ones
    if( a.acceleration.x < accel_x - offset || a.acceleration.x > accel_x + offset
    ||  a.acceleration.y < accel_y - offset || a.acceleration.y > accel_y + offset
    ||  a.acceleration.z < accel_z - offset || a.acceleration.z > accel_z + offset)
    {
      // On movement detection
      digitalWrite(LED_BUILTIN,HIGH);
    }
    else
    {
      // On no movement detection
      digitalWrite(LED_BUILTIN,LOW);
    }
    Serial.print(a.acceleration.x); Serial.print(",");
    Serial.print(a.acceleration.y); Serial.print(",");
    Serial.print(a.acceleration.z); Serial.println();
    
    accel_x = a.acceleration.x;
    accel_y = a.acceleration.y;
    accel_z = a.acceleration.z;
    Serial.flush();
  }

  // Power down MPU6050
  pinMode(A2,OUTPUT); digitalWrite(A2,LOW);
  // Pull I2C lines low to prevent current leaking via SDA and SCL
  pinMode(A4,OUTPUT); digitalWrite(A4,LOW);
  pinMode(A5,OUTPUT); digitalWrite(A5,LOW);
  
  // Arduino sleep
  delay(2000);
  // You have to install https://www.arduino.cc/en/Reference/ArduinoLowPower
  //LowPower.powerDown(SLEEP_2S, ADC_OFF, BOD_OFF);  
}
```
Note: First number is avail free ram

Example output (after change):
```
13:10:04.686 -> Heap,Accel_X,Accel_Y,Accel_Z
13:10:04.733 -> 1212,0.09,0.22,8.48
13:10:07.040 -> 1212,0.12,0.15,8.40
13:10:09.383 -> 1212,0.15,0.23,8.49
13:10:11.679 -> 1212,0.14,0.25,8.53
13:10:14.010 -> 1212,0.18,0.23,8.55
13:10:16.350 -> 1212,0.10,0.06,6.96
13:10:18.650 -> 1212,0.19,0.28,8.51
13:10:20.958 -> 1212,0.07,0.25,8.54
13:10:23.297 -> 1212,0.16,0.23,8.47
13:10:25.638 -> 1212,0.11,0.25,8.49
```

Example output (before change):
```
13:11:25.700 -> Heap,Accel_X,Accel_Y,Accel_Z
13:11:25.747 -> 1212,0.19,0.28,8.47
13:11:28.054 -> 1185,0.17,0.29,8.52
13:11:30.398 -> 1158,0.18,0.26,8.58
13:11:32.714 -> 1131,0.20,0.24,8.50
13:11:35.061 -> 1104,0.09,0.27,8.56
13:11:37.353 -> 1077,0.19,0.23,8.57
```


