### PR TITLE
Add documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Documentation is produced by doxygen. Contributions should include documentation
 
 Some examples of how to use doxygen can be found in these guide pages:
 
-https://learn.adafruit.com/the-well-automated-arduino-library/doxygen
+[About Doxygen](https://learn.adafruit.com/the-well-automated-arduino-library/doxygen)
 
-https://learn.adafruit.com/the-well-automated-arduino-library/doxygen-tips
+[Doxygen Tips](https://learn.adafruit.com/the-well-automated-arduino-library/doxygen-tips)
 
 ## Formatting and clang-format
 This library uses [`clang-format`](https://releases.llvm.org/download.html) to standardize the formatting of `.cpp` and `.h` files.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Contributions are welcome! Please read our [Code of Conduct](https://github.com/
 before contributing to help this project stay welcoming.
 
 ## Documentation and doxygen
+
+[Documentation on Github pages](https://adafruit.github.io/Adafruit_MPU6050/html/class_adafruit___m_p_u6050.html)
+
 Documentation is produced by doxygen. Contributions should include documentation for any new code added.
 
 Some examples of how to use doxygen can be found in these guide pages:


### PR DESCRIPTION
This PR updates the README by adding a link to the Doxygen documentation (https://adafruit.github.io/Adafruit_MPU6050/html/class_adafruit___m_p_u6050.html). 

Additionally, I formatted the 2 Doxygen guide links in the "Documentation" section. 
