### PR TITLE
Enable interrupt generation

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -353,6 +353,36 @@ void Adafruit_MPU6050::setInterruptPinPolarity(bool active_low) {
 
 /**************************************************************************/
 /*!
+*     @brief  Enables interrupt generation by a interrupt source
+*     @param  int_source
+*             The `mpu6050_int_source_t` specifying the interrupt source
+*/
+/**************************************************************************/
+void Adafruit_MPU6050::enableInterrupt(mpu6050_int_source_t int_source) {
+  Adafruit_BusIO_Register int_pin_config =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_INT_ENABLE, 1);
+  Adafruit_BusIO_RegisterBits int_level =
+      Adafruit_BusIO_RegisterBits(&int_pin_config, 1, int_source);
+  int_level.write(1);
+}
+
+/**************************************************************************/
+/*!
+*     @brief  Disables interrupt generation by a interrupt source
+*     @param  int_source
+*             The `mpu6050_int_source_t` specifying the interrupt source
+*/
+/**************************************************************************/
+void Adafruit_MPU6050::disableInterrupt(mpu6050_int_source_t int_source) {
+  Adafruit_BusIO_Register int_pin_config =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_INT_ENABLE, 1);
+  Adafruit_BusIO_RegisterBits int_level =
+      Adafruit_BusIO_RegisterBits(&int_pin_config, 1, int_source);
+  int_level.write(0);
+}
+
+/**************************************************************************/
+/*!
 *     @brief  Connects or disconects the I2C master pins to the main I2C pins
 *     @param  bypass
               If `true` the I2C Master pins are connected to the main I2C pins,

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -41,6 +41,7 @@
 #define MPU6050_ACCEL_CONFIG                                                   \
   0x1C ///< Accelerometer specific configration register
 #define MPU6050_INT_PIN_CONFIG 0x37    ///< Interrupt pin configuration register
+#define MPU6050_INT_ENABLE 0x38        ///< Interrupt enable register
 #define MPU6050_WHO_AM_I 0x75          ///< Divice ID register
 #define MPU6050_SIGNAL_PATH_RESET 0x68 ///< Signal path reset register
 #define MPU6050_USER_CTRL 0x6A         ///< FIFO and I2C Master control register
@@ -132,6 +133,17 @@ typedef enum {
   MPU6050_CYCLE_40_HZ,   ///< 40 Hz
 } mpu6050_cycle_rate_t;
 
+/**
+ * @brief Interrupt options
+ *
+ * Allowed values for `enableInterrupt` and `disableInterrupt`.
+ */
+typedef enum {
+  MPU6050_DATA_RDY_EN = 0,    ///< Enables the Data Ready interrupt
+  MPU6050_I2C_MST_INT_EN = 3, ///< Enables any of the I2C Master interrupt sources
+  MPU6050_FIFO_OFLOW_EN = 4,  ///< Enables a FIFO buffer overflow interrupt
+} mpu6050_int_source_t;
+
 class Adafruit_MPU6050;
 
 /** Adafruit Unified Sensor interface for temperature component of MPU6050 */
@@ -202,6 +214,8 @@ public:
   void setGyroRange(mpu6050_gyro_range_t);
 
   void setInterruptPinPolarity(bool active_low);
+  void enableInterrupt(mpu6050_int_source_t int_source);
+  void disableInterrupt(mpu6050_int_source_t int_source);
   void setFsyncSampleOutput(mpu6050_fsync_out_t fsync_output);
 
   mpu6050_fsync_out_t getFsyncSampleOutput(void);

--- a/examples/interrupt_readings/interrupt_readings.ino
+++ b/examples/interrupt_readings/interrupt_readings.ino
@@ -1,0 +1,83 @@
+// Basic demo for accelerometer readings from Adafruit MPU6050
+
+#include <Adafruit_MPU6050.h>
+#include <Adafruit_Sensor.h>
+#include <Wire.h>
+
+// Configure MPU6050_INT_PIN according to your hardware: https://www.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/
+#define MPU6050_INT_PIN 2   // On UNO, pins 2 or 3 are available
+
+Adafruit_MPU6050 mpu;
+volatile bool MPU6050_DataReady;
+
+void setup(void) {
+  Serial.begin(115200);
+  while (!Serial)
+    delay(10); // will pause Zero, Leonardo, etc until serial console opens
+
+  Serial.println("Adafruit MPU6050 test!");
+
+  // Try to initialize!
+  if (!mpu.begin()) {
+    Serial.println("Failed to find MPU6050 chip");
+    while (1) {
+      delay(10);
+    }
+  }
+  Serial.println("MPU6050 Found!");
+
+  mpu.setAccelerometerRange(MPU6050_RANGE_8_G);
+  mpu.setGyroRange(MPU6050_RANGE_500_DEG);
+  mpu.setFilterBandwidth(MPU6050_BAND_21_HZ);
+
+  // Set 5 Hz data rate
+  mpu.setSampleRateDivisor(200-1);
+
+  // Configure external interrupt
+  pinMode(MPU6050_INT_PIN, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(MPU6050_INT_PIN), MPU6050_Interrupt, RISING);
+
+  Serial.println("");
+  delay(100);
+
+  // Enable data ready interrupt generation
+  mpu.enableInterrupt(MPU6050_DATA_RDY_EN);
+}
+
+void MPU6050_Interrupt()
+{
+  MPU6050_DataReady = true;
+}
+
+void loop() {
+
+  while(!MPU6050_DataReady);
+  MPU6050_DataReady = false;
+  
+  /* Get new sensor events with the readings */
+  sensors_event_t a, g, temp;
+  mpu.getEvent(&a, &g, &temp);
+
+  /* Print out the values */
+  Serial.print("Acceleration X: ");
+  Serial.print(a.acceleration.x);
+  Serial.print(", Y: ");
+  Serial.print(a.acceleration.y);
+  Serial.print(", Z: ");
+  Serial.print(a.acceleration.z);
+  Serial.println(" m/s^2");
+
+  Serial.print("Rotation X: ");
+  Serial.print(g.gyro.x);
+  Serial.print(", Y: ");
+  Serial.print(g.gyro.y);
+  Serial.print(", Z: ");
+  Serial.print(g.gyro.z);
+  Serial.println(" rad/s");
+
+  Serial.print("Temperature: ");
+  Serial.print(temp.temperature);
+  Serial.println(" degC");
+
+  Serial.println("");
+}


### PR DESCRIPTION
Hello! The motivation for me creating this pull request is being able to generate interrupts on a GY-521 board. I basically created 2 functions, to enable and disable interrupt generation:

- void enableInterrupt(mpu6050_int_source_t int_source);
- void disableInterrupt(mpu6050_int_source_t int_source);

The enum 'mpu6050_int_source_t' specifies which type of interrupt generation source should generate an interrupt, according to register 0x38:

- FIFO Buffer Overflow Interrupt
- I2C Master Interrupt
- Data Ready Interrupt

Since I only required the Data Ready Interrupt, I didn't get to test the FIFO buffer overflow interrupt or the I2C Master Interrupt. But, as I believe you'll agree, their enabling should work well with these functions.

To show you how I intended to use these functions, I also created an example that worked on a Arduino Pro Micro with the GY-521 board. The name of the example is 'interrupt_readings'. To better organize these changes, I did 2 commits, one for editing the library and another for creating the example.

I hope you find these changes relevant and valuable! They certainly will be valuable to me, at least ;)