### PR TITLE
begin() was split up

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -58,6 +58,9 @@ Adafruit_MPU6050::~Adafruit_MPU6050(void) {
 
 /*!
  *    @brief  Sets up the hardware and initializes I2C
+ *    This call, unlike begin(), doesn't do an initialization of the
+ *    MPU6050 settings, and assumes that the user wants to maintain
+ *    the last settings.
  *    @param  i2c_address
  *            The I2C address to be used.
  *    @param  wire
@@ -66,9 +69,46 @@ Adafruit_MPU6050::~Adafruit_MPU6050(void) {
  *            The user-defined ID to differentiate different sensors
  *    @return True if initialization was successful, otherwise false.
  */
+bool Adafruit_MPU6050::init(uint8_t i2c_address, TwoWire *wire,
+                            int32_t sensor_id) {
+  if (!initI2C(i2c_address, wire)) {
+    return false;
+  }
 
+  _sensorid_accel = sensor_id;
+  _sensorid_gyro = sensor_id + 1;
+  _sensorid_temp = sensor_id + 2;
+  return true;
+}
+
+/*!
+ *    @brief  Sets up the hardware and initializes I2C
+ *    @param  i2c_address
+ *            The I2C address to be used.
+ *    @param  wire
+ *            The Wire object to be used for I2C connections.
+ *    @param sensor_id
+ *            The user-defined ID to differentiate different sensors
+ *    @return True if initialization was successful, otherwise false.
+ */
 bool Adafruit_MPU6050::begin(uint8_t i2c_address, TwoWire *wire,
                              int32_t sensor_id) {
+  if (!initI2C(i2c_address, wire)) {
+    return false;
+  }
+
+  return _init(sensor_id);
+}
+
+/*!
+ *    @brief  Initializes I2C
+ *    @param  i2c_address
+ *            The I2C address to be used.
+ *    @param  wire
+ *            The Wire object to be used for I2C connections.
+ *    @return True if initialization was successful, otherwise false.
+ */
+bool Adafruit_MPU6050::initI2C(uint8_t i2c_address, TwoWire *wire) {
   if (i2c_dev) {
     delete i2c_dev; // remove old interface
   }
@@ -87,7 +127,7 @@ bool Adafruit_MPU6050::begin(uint8_t i2c_address, TwoWire *wire,
     return false;
   }
 
-  return _init(sensor_id);
+  return true;
 }
 
 /*!  @brief Initilizes the sensor

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -208,6 +208,9 @@ public:
   Adafruit_MPU6050();
   ~Adafruit_MPU6050();
 
+  bool init(uint8_t i2c_addr = MPU6050_I2CADDR_DEFAULT, TwoWire *wire = &Wire,
+             int32_t sensorID = 0);
+
   bool begin(uint8_t i2c_addr = MPU6050_I2CADDR_DEFAULT, TwoWire *wire = &Wire,
              int32_t sensorID = 0);
 
@@ -259,6 +262,7 @@ public:
 private:
   void _getRawSensorData(void);
   void _scaleSensorData(void);
+  bool initI2C(uint8_t i2c_address, TwoWire *wire);
 
 protected:
   float temperature, ///< Last reading's temperature (C)


### PR DESCRIPTION
The ESP32 has a deep sleep mode, which returns, not to where deep sleep was initiated, but to setup() all over again. A difference between that and a regular reset or power is that the RTC variables are not zeroed out.

An MPU6050 can be connected to the ESP32 and be allowed to continue looking for motion, while the ESP32 is asleep. When the MPU6050 wakes the ESP32 back, it is good to be able to access the MPU6050's interrupt and other registers. However, if the only way to regain communication with the MPU6050 through I2C, is by calling a `mpu.begin()`, then `begin()` will reset the MPU and erase the interesting data.

This PR attempts to show one workaround. `begin()` is split into a private function `initI2C()` and there is also an `init()` call added. Normally, users will use `begin()` as before. The behavior should be unchanged.

Users who wish to preserve the contents of the MPU can call `init()`, which only does the bare minimum to restore communication with the MPU via i2c.

There are two ways (at least) to know whether the MPU has already been set up
- a `RTC_DATA_ATTR int bootCount = 0;` that is incremented by `setup()`. This will always be 0 if the ESP32 has been reset or is powered up, or non-zero if it is waking up. 
- do an `init()` call, check the MPU6050's registers for known values you had set before and if you don't find those, then call `begin()`.