### PR TITLE
Add gyro, accelerometer, and temperature enable/disable.

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -566,7 +566,8 @@ void Adafruit_MPU6050::setCycleRate(mpu6050_cycle_rate_t rate) {
  *     @return True if setting was successful, otherwise false.
  */
 /**************************************************************************/
-bool Adafruit_MPU6050::enableGyroStandby(bool xAxisEnable, bool yAxisEnable, bool zAxisEnable) {
+bool Adafruit_MPU6050::enableGyroStandby(bool xAxisEnable, bool yAxisEnable,
+                                         bool zAxisEnable) {
   Adafruit_BusIO_Register pwr_mgmt_2 =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_2, 1);
 
@@ -590,7 +591,8 @@ bool Adafruit_MPU6050::enableGyroStandby(bool xAxisEnable, bool yAxisEnable, boo
  *     @return True if setting was successful, otherwise false.
  */
 /**************************************************************************/
-bool Adafruit_MPU6050::enableAccelerometerStandby(bool xAxisEnable, bool yAxisEnable,
+bool Adafruit_MPU6050::enableAccelerometerStandby(bool xAxisEnable,
+                                                  bool yAxisEnable,
                                                   bool zAxisEnable) {
   Adafruit_BusIO_Register pwr_mgmt_2 =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_2, 1);

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -554,52 +554,52 @@ void Adafruit_MPU6050::setCycleRate(mpu6050_cycle_rate_t rate) {
 /**************************************************************************/
 /*!
  *     @brief  Sets standbye mode for each of the gyroscope axes.
- *     @param  xAxisEnable
+ *     @param  xAxisStandby
  *             If `true` the gyroscope stops sensing in the X-axis.
  *             Setting `false` resumes X-axis sensing.
- *     @param  yAxisEnable
+ *     @param  yAxisStandby
  *             If `true` the gyroscope stops sensing in the Y-axis.
  *             Setting `false` resumes Y-axis sensing.
- *     @param  zAxisEnable
+ *     @param  zAxisStandby
  *             If `true` the gyroscope stops sensing in the Z-axis.
  *             Setting `false` resumes Z-axis sensing.
  *     @return True if setting was successful, otherwise false.
  */
 /**************************************************************************/
-bool Adafruit_MPU6050::setGyroStandby(bool xAxisEnable, bool yAxisEnable,
-                                      bool zAxisEnable) {
+bool Adafruit_MPU6050::setGyroStandby(bool xAxisStandby, bool yAxisStandby,
+                                      bool zAxisStandby) {
   Adafruit_BusIO_Register pwr_mgmt_2 =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_2, 1);
 
   Adafruit_BusIO_RegisterBits gyro_stdby =
       Adafruit_BusIO_RegisterBits(&pwr_mgmt_2, 3, 0);
-  return gyro_stdby.write(xAxisEnable << 2 | yAxisEnable << 1 | zAxisEnable);
+  return gyro_stdby.write(xAxisStandby << 2 | yAxisStandby << 1 | zAxisStandby);
 }
 
 /**************************************************************************/
 /*!
  *     @brief  Sets standbye mode for each of the accelerometer axes.
- *     @param  xAxisEnable
+ *     @param  xAxisStandby
  *             If `true` the accelerometer stops sensing in the X-axis.
  *             Setting `false` resumes X-axis sensing.
- *     @param  yAxisEnable
+ *     @param  yAxisStandby
  *             If `true` the accelerometer stops sensing in the Y-axis.
  *             Setting `false` resumes Y-axis sensing.
- *     @param  zAxisEnable
+ *     @param  zAxisStandby
  *             If `true` the accelerometer stops sensing in the Z-axis.
  *             Setting `false` resumes Z-axis sensing.
  *     @return True if setting was successful, otherwise false.
  */
 /**************************************************************************/
-bool Adafruit_MPU6050::setAccelerometerStandby(bool xAxisEnable,
-                                               bool yAxisEnable,
-                                               bool zAxisEnable) {
+bool Adafruit_MPU6050::setAccelerometerStandby(bool xAxisStandby,
+                                               bool yAxisStandby,
+                                               bool zAxisStandby) {
   Adafruit_BusIO_Register pwr_mgmt_2 =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_2, 1);
 
   Adafruit_BusIO_RegisterBits accel_stdby =
       Adafruit_BusIO_RegisterBits(&pwr_mgmt_2, 3, 3);
-  return accel_stdby.write(xAxisEnable << 2 | yAxisEnable << 1 | zAxisEnable);
+  return accel_stdby.write(xAxisStandby << 2 | yAxisStandby << 1 | zAxisStandby);
 }
 
 /**************************************************************************/

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -573,7 +573,8 @@ bool Adafruit_MPU6050::setGyroStandby(bool xAxisStandby, bool yAxisStandby,
 
   Adafruit_BusIO_RegisterBits gyro_stdby =
       Adafruit_BusIO_RegisterBits(&pwr_mgmt_2, 3, 0);
-  return gyro_stdby.write(xAxisStandby << 2 | yAxisStandby << 1 | zAxisStandby);
+  return gyro_stdby.write(xAxisStandby << 2 | yAxisStandby << 1 |
+                          zAxisStandby);
 }
 
 /**************************************************************************/
@@ -599,7 +600,8 @@ bool Adafruit_MPU6050::setAccelerometerStandby(bool xAxisStandby,
 
   Adafruit_BusIO_RegisterBits accel_stdby =
       Adafruit_BusIO_RegisterBits(&pwr_mgmt_2, 3, 3);
-  return accel_stdby.write(xAxisStandby << 2 | yAxisStandby << 1 | zAxisStandby);
+  return accel_stdby.write(xAxisStandby << 2 | yAxisStandby << 1 |
+                           zAxisStandby);
 }
 
 /**************************************************************************/

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -551,6 +551,74 @@ void Adafruit_MPU6050::setCycleRate(mpu6050_cycle_rate_t rate) {
   cycle_rate.write(rate);
 }
 
+/**************************************************************************/
+/*!
+ *     @brief  Sets standbye mode for each of the gyroscope axes.
+ *     @param  xAxisEnable
+ *             If `true` the gyroscope stops sensing in the X-axis.
+ *             Setting `false` resumes X-axis sensing.
+ *     @param  yAxisEnable
+ *             If `true` the gyroscope stops sensing in the Y-axis.
+ *             Setting `false` resumes Y-axis sensing.
+ *     @param  zAxisEnable
+ *             If `true` the gyroscope stops sensing in the Z-axis.
+ *             Setting `false` resumes Z-axis sensing.
+ *     @return True if setting was successful, otherwise false.
+ */
+/**************************************************************************/
+bool Adafruit_MPU6050::enableGyroStandby(bool xAxisEnable, bool yAxisEnable, bool zAxisEnable) {
+  Adafruit_BusIO_Register pwr_mgmt_2 =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_2, 1);
+
+  Adafruit_BusIO_RegisterBits gyro_stdby =
+      Adafruit_BusIO_RegisterBits(&pwr_mgmt_2, 3, 0);
+  return gyro_stdby.write(xAxisEnable << 2 | yAxisEnable << 1 | zAxisEnable);
+}
+
+/**************************************************************************/
+/*!
+ *     @brief  Sets standbye mode for each of the accelerometer axes.
+ *     @param  xAxisEnable
+ *             If `true` the accelerometer stops sensing in the X-axis.
+ *             Setting `false` resumes X-axis sensing.
+ *     @param  yAxisEnable
+ *             If `true` the accelerometer stops sensing in the Y-axis.
+ *             Setting `false` resumes Y-axis sensing.
+ *     @param  zAxisEnable
+ *             If `true` the accelerometer stops sensing in the Z-axis.
+ *             Setting `false` resumes Z-axis sensing.
+ *     @return True if setting was successful, otherwise false.
+ */
+/**************************************************************************/
+bool Adafruit_MPU6050::enableAccelerometerStandby(bool xAxisEnable, bool yAxisEnable,
+                                                  bool zAxisEnable) {
+  Adafruit_BusIO_Register pwr_mgmt_2 =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_2, 1);
+
+  Adafruit_BusIO_RegisterBits accel_stdby =
+      Adafruit_BusIO_RegisterBits(&pwr_mgmt_2, 3, 3);
+  return accel_stdby.write(xAxisEnable << 2 | yAxisEnable << 1 | zAxisEnable);
+}
+
+/**************************************************************************/
+/*!
+ *     @brief  Sets disable mode for thermometer sensor.
+ *     @param  enable
+ *             If `true` the temperature sensor will stop taking measurements.
+ *             Setting `false` returns the temperature sensor to the normal
+ *             measurement mode.
+ *     @return True if setting was successful, otherwise false.
+ */
+/**************************************************************************/
+bool Adafruit_MPU6050::enableTemperatureStandby(bool enable) {
+  Adafruit_BusIO_Register pwr_mgmt =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_1, 1);
+
+  Adafruit_BusIO_RegisterBits temp_stdby =
+      Adafruit_BusIO_RegisterBits(&pwr_mgmt, 1, 3);
+  return temp_stdby.write(1);
+}
+
 /******************* Adafruit_Sensor functions *****************/
 /*!
  *     @brief  Updates the measurement data for all sensors simultaneously

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -566,8 +566,8 @@ void Adafruit_MPU6050::setCycleRate(mpu6050_cycle_rate_t rate) {
  *     @return True if setting was successful, otherwise false.
  */
 /**************************************************************************/
-bool Adafruit_MPU6050::enableGyroStandby(bool xAxisEnable, bool yAxisEnable,
-                                         bool zAxisEnable) {
+bool Adafruit_MPU6050::setGyroStandby(bool xAxisEnable, bool yAxisEnable,
+                                      bool zAxisEnable) {
   Adafruit_BusIO_Register pwr_mgmt_2 =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_2, 1);
 
@@ -591,9 +591,9 @@ bool Adafruit_MPU6050::enableGyroStandby(bool xAxisEnable, bool yAxisEnable,
  *     @return True if setting was successful, otherwise false.
  */
 /**************************************************************************/
-bool Adafruit_MPU6050::enableAccelerometerStandby(bool xAxisEnable,
-                                                  bool yAxisEnable,
-                                                  bool zAxisEnable) {
+bool Adafruit_MPU6050::setAccelerometerStandby(bool xAxisEnable,
+                                               bool yAxisEnable,
+                                               bool zAxisEnable) {
   Adafruit_BusIO_Register pwr_mgmt_2 =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_2, 1);
 
@@ -612,7 +612,7 @@ bool Adafruit_MPU6050::enableAccelerometerStandby(bool xAxisEnable,
  *     @return True if setting was successful, otherwise false.
  */
 /**************************************************************************/
-bool Adafruit_MPU6050::enableTemperatureStandby(bool enable) {
+bool Adafruit_MPU6050::setTemperatureStandby(bool enable) {
   Adafruit_BusIO_Register pwr_mgmt =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_PWR_MGMT_1, 1);
 

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -573,8 +573,7 @@ bool Adafruit_MPU6050::setGyroStandby(bool xAxisStandby, bool yAxisStandby,
 
   Adafruit_BusIO_RegisterBits gyro_stdby =
       Adafruit_BusIO_RegisterBits(&pwr_mgmt_2, 3, 0);
-  return gyro_stdby.write(xAxisStandby << 2 | yAxisStandby << 1 |
-                          zAxisStandby);
+  return gyro_stdby.write(xAxisStandby << 2 | yAxisStandby << 1 | zAxisStandby);
 }
 
 /**************************************************************************/

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -251,9 +251,9 @@ public:
   void setCycleRate(mpu6050_cycle_rate_t rate);
   mpu6050_cycle_rate_t getCycleRate(void);
 
-  bool setGyroStandby(bool xAxisEnable, bool yAxisEnable, bool zAxisEnable);
-  bool setAccelerometerStandby(bool xAxisEnable, bool yAxisEnable,
-                               bool zAxisEnable);
+  bool setGyroStandby(bool xAxisStandby, bool yAxisStandby, bool zAxisStandby);
+  bool setAccelerometerStandby(bool xAxisStandby, bool yAxisStandby,
+                               bool zAxisStandby);
   bool setTemperatureStandby(bool enable);
 
   void reset(void);

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -251,11 +251,8 @@ public:
   void setCycleRate(mpu6050_cycle_rate_t rate);
   mpu6050_cycle_rate_t getCycleRate(void);
 
-  bool enableGyroStandby(bool xAxisEnable,
-                         bool yAxisEnable,
-                         bool zAxisEnable);
-  bool enableAccelerometerStandby(bool xAxisEnable,
-                                  bool yAxisEnable,
+  bool enableGyroStandby(bool xAxisEnable, bool yAxisEnable, bool zAxisEnable);
+  bool enableAccelerometerStandby(bool xAxisEnable, bool yAxisEnable,
                                   bool zAxisEnable);
   bool enableTemperatureStandby(bool enable);
 

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -251,10 +251,10 @@ public:
   void setCycleRate(mpu6050_cycle_rate_t rate);
   mpu6050_cycle_rate_t getCycleRate(void);
 
-  bool enableGyroStandby(bool xAxisEnable, bool yAxisEnable, bool zAxisEnable);
-  bool enableAccelerometerStandby(bool xAxisEnable, bool yAxisEnable,
-                                  bool zAxisEnable);
-  bool enableTemperatureStandby(bool enable);
+  bool setGyroStandby(bool xAxisEnable, bool yAxisEnable, bool zAxisEnable);
+  bool setAccelerometerStandby(bool xAxisEnable, bool yAxisEnable,
+                               bool zAxisEnable);
+  bool setTemperatureStandby(bool enable);
 
   void reset(void);
 

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -250,6 +250,15 @@ public:
 
   void setCycleRate(mpu6050_cycle_rate_t rate);
   mpu6050_cycle_rate_t getCycleRate(void);
+
+  bool enableGyroStandby(bool xAxisEnable,
+                         bool yAxisEnable,
+                         bool zAxisEnable);
+  bool enableAccelerometerStandby(bool xAxisEnable,
+                                  bool yAxisEnable,
+                                  bool zAxisEnable);
+  bool enableTemperatureStandby(bool enable);
+
   void reset(void);
 
   Adafruit_Sensor *getTemperatureSensor(void);


### PR DESCRIPTION
Three functions were added to allow for the gyro, accelerometer, and thermometer to be enabled or disabled. This is important for power management, or when a project only needs a subset of all those sensors. For example, a car project may not need to sense in three dimensions.

I've tested it the changes to some extent. I've verified changes to µA draws using a Fluke, and definitely see a huge drop in current draw when the gyro is off, a smaller reduction when the accelerometers are disabled. Disabling the thermometer didn't really change the amperage significantly.