### PR TITLE
Correct latch bit number

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -393,7 +393,7 @@ void Adafruit_MPU6050::setInterruptPinLatch(bool held) {
   Adafruit_BusIO_Register int_pin_config =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_INT_PIN_CONFIG, 1);
   Adafruit_BusIO_RegisterBits int_latch =
-      Adafruit_BusIO_RegisterBits(&int_pin_config, 1, 7);
+      Adafruit_BusIO_RegisterBits(&int_pin_config, 1, 5);
   int_latch.write(held);
 }
 


### PR DESCRIPTION
The bit number for the interrupt latch should be 5, I believe.

https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-6000-Register-Map1.pdf section 4.14