### PR TITLE
Add retry delay loop for boards with I2C power

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -75,9 +75,17 @@ bool Adafruit_MPU6050::begin(uint8_t i2c_address, TwoWire *wire,
 
   i2c_dev = new Adafruit_I2CDevice(i2c_address, wire);
 
-  if (!i2c_dev->begin()) {
-    return false;
+  // For boards with I2C bus power control, may need to delay to allow
+  // MPU6050 to come up after initial power.
+  bool mpu_found = false;
+  for (uint8_t tries = 0; tries < 5; tries++) {
+    mpu_found = i2c_dev->begin();
+    if (mpu_found)
+      break;
+    delay(10);
   }
+  if (!mpu_found)
+    return false;
 
   Adafruit_BusIO_Register chip_id =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_WHO_AM_I, 1);


### PR DESCRIPTION
On a Feather ESP32 ([PID 3405](https://www.adafruit.com/product/3405)), the [basic_readings](https://github.com/adafruit/Adafruit_MPU6050/tree/master/examples/basic_readings) example runs as expected:
```
Adafruit MPU6050 test!
MPU6050 Found!
Accelerometer range set to: +-8G
Gyro range set to: +- 500 deg/s
Filter bandwidth set to: 21 Hz

Acceleration X: 0.05, Y: 4.81, Z: 7.80 m/s^2
Rotation X: -0.04, Y: 0.02, Z: -0.01 rad/s
Temperature: 22.87 degC

Acceleration X: 0.06, Y: 4.82, Z: 7.78 m/s^2
Rotation X: -0.05, Y: 0.00, Z: -0.01 rad/s
Temperature: 23.01 degC
```

However, on a Feather ESP32 V2 ([PID 5400](https://www.adafruit.com/product/5400)), which has a powerable I2C bus, the MPU fails to be found:
```
Adafruit MPU6050 test!
Failed to find MPU6050 chip
```

Can get it working again on the Feather ESP32 V2 by adding a small delay (`delay(10)`) as first line in `setup()`. So most likely a power on race condition. The MPU needs more time once the I2C bus is powered before trying to talk to it.

This PR adds a retry loop with delay in `::begin()` as a work around for this scenario.