### PR TITLE
Corrected a typo in setTemperatureStandby.

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -619,7 +619,7 @@ bool Adafruit_MPU6050::setTemperatureStandby(bool enable) {
 
   Adafruit_BusIO_RegisterBits temp_stdby =
       Adafruit_BusIO_RegisterBits(&pwr_mgmt, 1, 3);
-  return temp_stdby.write(1);
+  return temp_stdby.write(enable);
 }
 
 /******************* Adafruit_Sensor functions *****************/


### PR DESCRIPTION
There was a typo where the `temp_stdby.write` call was using `1` as an argument instead of using the method's `enable` argument. This made the temperature sensor to become disabled everytime this method was used. Changing the argument of that call to `enable` seems to solve the issue.