### PR TITLE
fix: getEvent() checks _read() return

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -635,13 +635,15 @@ bool Adafruit_MPU6050::setTemperatureStandby(bool enable) {
  *     @brief  Updates the measurement data for all sensors simultaneously
  */
 /**************************************************************************/
-void Adafruit_MPU6050::_read(void) {
+bool Adafruit_MPU6050::_read(void) {
   // get raw readings
   Adafruit_BusIO_Register data_reg =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_ACCEL_OUT, 14);
 
   uint8_t buffer[14];
-  data_reg.read(buffer, 14);
+  bool ret = data_reg.read(buffer, 14);
+
+  if (!ret) return false;
 
   rawAccX = buffer[0] << 8 | buffer[1];
   rawAccY = buffer[2] << 8 | buffer[3];
@@ -687,6 +689,8 @@ void Adafruit_MPU6050::_read(void) {
   gyroX = ((float)rawGyroX) / gyro_scale;
   gyroY = ((float)rawGyroY) / gyro_scale;
   gyroZ = ((float)rawGyroZ) / gyro_scale;
+
+  return true;
 }
 
 /**************************************************************************/
@@ -707,7 +711,9 @@ void Adafruit_MPU6050::_read(void) {
 bool Adafruit_MPU6050::getEvent(sensors_event_t *accel, sensors_event_t *gyro,
                                 sensors_event_t *temp) {
   uint32_t timestamp = millis();
-  _read();
+  bool ret = _read();
+
+  if (!ret) return false;
 
   fillTempEvent(temp, timestamp);
   fillAccelEvent(accel, timestamp);

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -286,7 +286,7 @@ protected:
       _sensorid_gyro,       ///< ID number for gyro
       _sensorid_temp;       ///< ID number for temperature
 
-  void _read(void);
+  bool _read(void);
   virtual bool _init(int32_t sensor_id);
 
 private:


### PR DESCRIPTION
`_read()` now returns a bool. If it was successful, it'll return a true.

In a `getEvent()` overload that fills in the accel, gyro, and temp, we're not checking the `_read()` return. That way, we know if there is failure or not.