### PR TITLE
add offset register control

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -892,8 +892,15 @@ mpu6050_offset_t Adafruit_MPU6050::getGyroOffsets(void)
     mpu6050_offset_t offSet = {.x = 0, .y = 0, .z = 0};
     Adafruit_I2CDevice *i2c_dev = getI2cDev();
     Adafruit_BusIO_Register OffSetReg =
-      Adafruit_BusIO_Register(i2c_dev, MPU6050_XG_OFFSET_H, sizeof(mpu6050_offset_t), 1);
-    OffSetReg.read((uint16_t*)&offSet);
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_XG_OFFSET_H, sizeof(mpu6050_offset_t));
+    
+    uint8_t buffer[sizeof(mpu6050_offset_t)];
+    OffSetReg.read(buffer, sizeof(mpu6050_offset_t));
+
+    offSet.x = buffer[0] << 8 | buffer[1];
+    offSet.y = buffer[2] << 8 | buffer[3];
+    offSet.z = buffer[4] << 8 | buffer[5];
+
     return offSet;
 }
 
@@ -901,8 +908,18 @@ void Adafruit_MPU6050::setGyroOffsets(mpu6050_offset_t offset)
 {
     Adafruit_I2CDevice *i2c_dev = getI2cDev();
     Adafruit_BusIO_Register OffSetReg =
-      Adafruit_BusIO_Register(i2c_dev, MPU6050_XG_OFFSET_H, sizeof(mpu6050_offset_t), 1);
-    OffSetReg.write((uint8_t*)&offset, sizeof(mpu6050_offset_t));
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_XG_OFFSET_H, sizeof(mpu6050_offset_t));
+
+    uint8_t buffer[sizeof(mpu6050_offset_t)];
+
+    buffer[0] = ((uint8_t*)&offset.x)[1];
+    buffer[1] = ((uint8_t*)&offset.x)[0];
+    buffer[2] = ((uint8_t*)&offset.y)[1];
+    buffer[3] = ((uint8_t*)&offset.y)[0];
+    buffer[4] = ((uint8_t*)&offset.z)[1];
+    buffer[5] = ((uint8_t*)&offset.z)[0];
+
+    OffSetReg.write(buffer, sizeof(mpu6050_offset_t));
 }
 
 mpu6050_offset_t Adafruit_MPU6050::getAccelerometerOffsets(void)
@@ -911,7 +928,14 @@ mpu6050_offset_t Adafruit_MPU6050::getAccelerometerOffsets(void)
     Adafruit_I2CDevice *i2c_dev = getI2cDev();
     Adafruit_BusIO_Register OffSetReg =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_XA_OFFSET_H, sizeof(mpu6050_offset_t), 1);
-    OffSetReg.read((uint16_t*)&offSet);
+    
+    uint8_t buffer[sizeof(mpu6050_offset_t)];
+    OffSetReg.read(buffer, sizeof(mpu6050_offset_t));
+
+    offSet.x = buffer[0] << 8 | buffer[1];
+    offSet.y = buffer[2] << 8 | buffer[3];
+    offSet.z = buffer[4] << 8 | buffer[5];
+    
     return offSet;
 }
 
@@ -920,5 +944,15 @@ void Adafruit_MPU6050::setAccelerometerOffsets(mpu6050_offset_t offset)
     Adafruit_I2CDevice *i2c_dev = getI2cDev();
     Adafruit_BusIO_Register OffSetReg =
       Adafruit_BusIO_Register(i2c_dev, MPU6050_XA_OFFSET_H, sizeof(mpu6050_offset_t), 1);
-    OffSetReg.write((uint8_t*)&offset, sizeof(mpu6050_offset_t));
+    
+    uint8_t buffer[sizeof(mpu6050_offset_t)];
+
+    buffer[0] = ((uint8_t*)&offset.x)[1];
+    buffer[1] = ((uint8_t*)&offset.x)[0];
+    buffer[2] = ((uint8_t*)&offset.y)[1];
+    buffer[3] = ((uint8_t*)&offset.y)[0];
+    buffer[4] = ((uint8_t*)&offset.z)[1];
+    buffer[5] = ((uint8_t*)&offset.z)[0];
+    
+    OffSetReg.write(buffer, sizeof(mpu6050_offset_t));
 }

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -137,6 +137,8 @@ bool Adafruit_MPU6050::_init(int32_t sensor_id) {
   accel_sensor = new Adafruit_MPU6050_Accelerometer(this);
   gyro_sensor = new Adafruit_MPU6050_Gyro(this);
 
+
+
   return true;
 }
 /**************************************************************************/
@@ -877,4 +879,46 @@ bool Adafruit_MPU6050_Temp::getEvent(sensors_event_t *event) {
   _theMPU6050->fillTempEvent(event, millis());
 
   return true;
+}
+
+
+/**
+ * @brief OffSet Control
+ * 
+ */
+
+mpu6050_offset_t Adafruit_MPU6050::getGyroOffsets(void)
+{
+    mpu6050_offset_t offSet = {.x = 0, .y = 0, .z = 0};
+    Adafruit_I2CDevice *i2c_dev = getI2cDev();
+    Adafruit_BusIO_Register OffSetReg =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_XG_OFFSET_H, sizeof(mpu6050_offset_t), 1);
+    OffSetReg.read((uint16_t*)&offSet);
+    return offSet;
+}
+
+void Adafruit_MPU6050::setGyroOffsets(mpu6050_offset_t offset)
+{
+    Adafruit_I2CDevice *i2c_dev = getI2cDev();
+    Adafruit_BusIO_Register OffSetReg =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_XG_OFFSET_H, sizeof(mpu6050_offset_t), 1);
+    OffSetReg.write((uint8_t*)&offset, sizeof(mpu6050_offset_t));
+}
+
+mpu6050_offset_t Adafruit_MPU6050::getAccelerometerOffsets(void)
+{
+    mpu6050_offset_t offSet = {.x = 0, .y = 0, .z = 0};
+    Adafruit_I2CDevice *i2c_dev = getI2cDev();
+    Adafruit_BusIO_Register OffSetReg =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_XA_OFFSET_H, sizeof(mpu6050_offset_t), 1);
+    OffSetReg.read((uint16_t*)&offSet);
+    return offSet;
+}
+
+void Adafruit_MPU6050::setAccelerometerOffsets(mpu6050_offset_t offset)
+{
+    Adafruit_I2CDevice *i2c_dev = getI2cDev();
+    Adafruit_BusIO_Register OffSetReg =
+      Adafruit_BusIO_Register(i2c_dev, MPU6050_XA_OFFSET_H, sizeof(mpu6050_offset_t), 1);
+    OffSetReg.write((uint8_t*)&offset, sizeof(mpu6050_offset_t));
 }

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -55,6 +55,22 @@
 #define MPU6050_MOT_DUR                                                        \
   0x20 ///< Duration counter threshold for motion int. 1 kHz rate, LSB = 1 ms
 
+// Accelerometer offset register
+#define MPU6050_XA_OFFSET_H 0x06 //6
+#define MPU6050_XA_OFFSET_L 0x07 //7
+#define MPU6050_YA_OFFSET_H 0x08 //8
+#define MPU6050_YA_OFFSET_L 0x09 //9
+#define MPU6050_ZA_OFFSET_H 0x0A //10
+#define MPU6050_ZA_OFFSET_L 0x0B //11
+
+// Gyroscope offset register
+#define MPU6050_XG_OFFSET_H 0x13 //19
+#define MPU6050_XG_OFFSET_L 0x14 //20
+#define MPU6050_YG_OFFSET_H 0x15 //21
+#define MPU6050_YG_OFFSET_L 0x16 //22
+#define MPU6050_ZG_OFFSET_H 0x17 //23
+#define MPU6050_ZG_OFFSET_L 0x18 //24
+
 /**
  * @brief FSYNC output values
  *
@@ -261,7 +277,9 @@ public:
   Adafruit_Sensor *getTemperatureSensor(void);
   Adafruit_Sensor *getAccelerometerSensor(void);
   Adafruit_Sensor *getGyroSensor(void);
-
+  Adafruit_I2CDevice * getI2cDev(void){
+    return i2c_dev;
+  }
 private:
   void _getRawSensorData(void);
   void _scaleSensorData(void);

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -168,6 +168,16 @@ typedef enum {
   MPU6050_CYCLE_40_HZ,   ///< 40 Hz
 } mpu6050_cycle_rate_t;
 
+/**
+ * @brief offSet for gyro and accel sensor
+ * 
+ */
+typedef struct {
+  int16_t x;
+  int16_t y;
+  int16_t z;
+} mpu6050_offset_t;
+
 class Adafruit_MPU6050;
 
 /** Adafruit Unified Sensor interface for temperature component of MPU6050 */
@@ -273,6 +283,12 @@ public:
   bool setTemperatureStandby(bool enable);
 
   void reset(void);
+
+  //offset control
+  mpu6050_offset_t getGyroOffsets(void);
+  void setGyroOffsets(mpu6050_offset_t offset);
+  mpu6050_offset_t getAccelerometerOffsets(void);
+  void setAccelerometerOffsets(mpu6050_offset_t offset);
 
   Adafruit_Sensor *getTemperatureSensor(void);
   Adafruit_Sensor *getAccelerometerSensor(void);


### PR DESCRIPTION
+ I add set and get function for use gyro and accelerometer offset register.
my code add to the end of the "Adafruit_MPU6050.cpp" and "Adafruit_MPU6050" class.
and I add a function that have not necessary for this functionality that give I2C class object to users if they want to use custom register of MPU as "getI2cDev" on "Adafruit_MPU6050.h" line 296, in same class (Adafruit_MPU6050).

+ I test it code on ESP32 and work correctly