### PR TITLE
Fix incorrect docstring

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -2,11 +2,11 @@
 /*!
  *  @file Adafruit_MPU6050.cpp
  *
- *  @mainpage Adafruit MPU6050 proximity and ambient light sensor library
+ *  @mainpage Adafruit MPU6050 6-DoF Accelerometer and Gyro Library
  *
  *  @section intro_sec Introduction
  *
- * 	I2C Driver for the MPU6050 proximity and ambient light sensor library
+ * 	I2C Driver for the MPU6050 6-DoF accelerometer and gyro sensor library
  *
  * 	This is a library for the Adafruit MPU6050 breakout:
  * 	https://www.adafruit.com/product/3886

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -23,9 +23,8 @@
 #include <Adafruit_Sensor.h>
 #include <Wire.h>
 
-#define MPU6050_I2CADDR_DEFAULT                                                \
-  0x68                         ///< MPU6050 default i2c address w/ AD0 low
-#define MPU6050_DEVICE_ID 0x68 ///< The correct MPU6050_WHO_AM_I value
+#define MPU6050_I2CADDR_DEFAULT 0x68 ///< MPU6050 default i2c address w/ AD0 low
+#define MPU6050_DEVICE_ID 0x68       ///< The correct MPU6050_WHO_AM_I value
 
 #define MPU6050_SELF_TEST_X                                                    \
   0x0D ///< Self test factory calibrated values register


### PR DESCRIPTION
For #30.

Simple copy pasta clean up.

Hopefully all of them based on a simple grep search:
```
$ grep -n -r -i proximity
Adafruit_MPU6050.cpp:5: *  @mainpage Adafruit MPU6050 proximity and ambient light sensor library
Adafruit_MPU6050.cpp:9: * 	I2C Driver for the MPU6050 proximity and ambient light sensor library
```