### PR TITLE
Add ability to set custom DEVICE_ID when using knockoff sensors

### DIFF
--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -59,7 +59,8 @@ Adafruit_MPU6050::~Adafruit_MPU6050(void) {
 /*!
  *    @brief  Sets up the hardware and initializes I2C
  *    @param alt_ID
- *            In the case of a knockoff sensor, this is the user-provided I2C device ID
+ *            In the case of a knockoff sensor, this is the user-provided I2C
+ *            device ID
  *    @param  i2c_address
  *            The I2C address to be used.
  *    @param  wire

--- a/Adafruit_MPU6050.cpp
+++ b/Adafruit_MPU6050.cpp
@@ -58,6 +58,8 @@ Adafruit_MPU6050::~Adafruit_MPU6050(void) {
 
 /*!
  *    @brief  Sets up the hardware and initializes I2C
+ *    @param alt_ID
+ *            In the case of a knockoff sensor, this is the user-provided I2C device ID
  *    @param  i2c_address
  *            The I2C address to be used.
  *    @param  wire
@@ -67,7 +69,7 @@ Adafruit_MPU6050::~Adafruit_MPU6050(void) {
  *    @return True if initialization was successful, otherwise false.
  */
 
-bool Adafruit_MPU6050::begin(uint8_t i2c_address, TwoWire *wire,
+bool Adafruit_MPU6050::begin(int32_t alt_ID, uint8_t i2c_address, TwoWire *wire,
                              int32_t sensor_id) {
   if (i2c_dev) {
     delete i2c_dev; // remove old interface
@@ -91,7 +93,7 @@ bool Adafruit_MPU6050::begin(uint8_t i2c_address, TwoWire *wire,
       Adafruit_BusIO_Register(i2c_dev, MPU6050_WHO_AM_I, 1);
 
   // make sure we're talking to the right chip
-  if (chip_id.read() != MPU6050_DEVICE_ID) {
+  if (chip_id.read() != alt_ID) {
     return false;
   }
 

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -207,7 +207,7 @@ public:
   Adafruit_MPU6050();
   ~Adafruit_MPU6050();
 
-  bool begin(uint8_t i2c_addr = MPU6050_I2CADDR_DEFAULT, TwoWire *wire = &Wire,
+  bool begin(int32_t alt_ID = MPU6050_DEVICE_ID, uint8_t i2c_addr = MPU6050_I2CADDR_DEFAULT, TwoWire *wire = &Wire,
              int32_t sensorID = 0);
 
   // Adafruit_Sensor API/Interface

--- a/Adafruit_MPU6050.h
+++ b/Adafruit_MPU6050.h
@@ -207,7 +207,8 @@ public:
   Adafruit_MPU6050();
   ~Adafruit_MPU6050();
 
-  bool begin(int32_t alt_ID = MPU6050_DEVICE_ID, uint8_t i2c_addr = MPU6050_I2CADDR_DEFAULT, TwoWire *wire = &Wire,
+  bool begin(int32_t alt_ID = MPU6050_DEVICE_ID,
+             uint8_t i2c_addr = MPU6050_I2CADDR_DEFAULT, TwoWire *wire = &Wire,
              int32_t sensorID = 0);
 
   // Adafruit_Sensor API/Interface


### PR DESCRIPTION
Both the header and source file are modified such that begin() takes in an extra parameter that allows the user to set a custom I2C device ID. If left blank, the library sets the ID to the default value (0x68).

Using provided sample code to demonstrate:
```
// Try to initialize!
  if (!mpu.begin(0x70)) {
    Serial.println("Failed to find MPU6050 chip");
    while (1) {
      delay(10);
    }
  }
  Serial.println("MPU6050 Found!");
```

This would fix problems such as the one listed in issue #47 where certain sensors identify themselves with the correct I2C address but do not have the correct I2C device ID, resulting in the library failing to initialize the sensor. 
These sensors work properly once the ID is manually set in the header file, but this provides a way for it to be set in the user's code.

